### PR TITLE
Update tjuthesis-Bachelor.cls

### DIFF
--- a/tjuthesis-Bachelor.cls
+++ b/tjuthesis-Bachelor.cls
@@ -145,19 +145,19 @@
   \end{figure}
 }
 
-\newcommand{\tablemacro}[5]{ %表格插入宏
-    \begin{table}[#1] %第一个参数是浮动体样式设置
-    \centering
-    \caption{#2}\zihao{5} %第二个参数是表格标题
-    \begin{tabular}{ccc}
-        \toprule
-        #3 %第三个参数是表格列标题，需要手动使用\songtibf加粗
-        \midrule
-        #4 %第四个参数是表格内容
-        \bottomrule
-    \end{tabular}
-    \label{#5} %第五个参数是表格标签
-\end{table}
+\newcommand{\tablemacro}[6]{ % 表格插入宏
+	\begin{table}[#1]
+		\centering
+		\caption{#2}\zihao{5} % 设置表格内容为五号字
+		\begin{tabular*}{\textwidth}{@{\extracolsep{\fill}}#3}
+			\toprule
+			#4 % 表头内容
+			\midrule
+			#5 % 表格主体
+			\bottomrule
+		\end{tabular*}
+		\label{#6}
+	\end{table}
 }
 
 \addbibresource{reference.bib} %添加参考文献数据库文件


### PR DESCRIPTION
笔者在使用`\tablemacro`插入六列表格的时候发现报错，系[tjuthesis-Bachelor.cls](https://github.com/OmegaAndre/TJUThesis-2026-Graduation-Bachelor/blob/main/tjuthesis-Bachelor.cls)文件中`\begin{tabular}{ccc}`处写死。

现做以下补充，实现了自定义列数表格插入及表格宽度自动填满一行：

- 更新cls文件
- 正文中使用时，标题与表格题头之间补充一行{cccc…}注明列数，示例
```
\tablemacro{htbp}
	{标题}
	{cccccc} %六列为例
	{\songtibf{材料} & \songtibf{光栅深度} & \songtibf{类型} & \songtibf{栅距} & \songtibf{激光波长} & \songtibf{$\kappa L$} \\}
	{InP & xxx $nm$ & 侧壁均匀 & xxx $nm$ & 双边模式 & xxxx\\
		InP & xxx $nm$ & 侧壁均匀 & xxx $nm$ & 双边模式 & xxxx \\
		InP & xxx $nm$ & 侧壁相移 & xxx $nm$ & xxxx $nm$ & xxxx \\
		InP & xxx $nm$ & 侧壁相移 & xxx $nm$ & xxxx $nm$ & xxxx \\
		GaAs & xxx $nm$ & 表面相移 & xxx $nm$ & xxxx $nm$ & xxxx  \\
		SiO$_2$ & xxx $nm$ & 表面相移 & xxx $nm$ & xxxx $nm$ & xxxx \\
		SiO$_2$ & xxx $nm$ & 表面相移 & xxx $nm$ & xxxx $nm$ & xxxx \\
		Si$_3$N$_4$ & xxx $nm$ & 表面相移 & xxx $nm$ & xxxx $nm$ & xxxx \\
		Si$_3$N$_4$ & 400 $nm$ & 表面相移 & xxx  $nm$ & xxxx $nm$ & xxxx \\}
	{label}
```
- 引用时，与原来保持一致
```
\ref{label}
```